### PR TITLE
Add macOS support (x64 and ARM64) for all Lua versions

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -8,38 +8,64 @@ on:
     branches: [main]
   push:
     tags:
-      - '*'
+      - "*"
     paths-ignore:
-      - '.github/**'
-      - 'docs/**'
-      - 'README.md'
+      - ".github/**"
+      - "docs/**"
+      - "README.md"
     branches:
       - main
 
 jobs:
+  apple-natives:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+      - run: echo "JAVA_17=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+      - name: Build natives
+        run: |
+          ./gradlew jniGen jnigenBuildMacOsX64 jnigenBuildMacOsXARM64
+      - name: Test
+        run: |
+          ./gradlew :example:test :jsr223:test :jpms-example:run
+      - name: Upload macOS natives
+        uses: actions/upload-artifact@v4
+        with:
+          name: apple-natives
+          path: ./*/libs
+          retention-days: 5
   most-natives:
     environment: Codecov
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '8'
+          distribution: "temurin"
+          java-version: "8"
       - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
       - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Download llvm-mingw
         uses: robinraju/release-downloader@v1.10
         with:
-          repository: 'mstorsjo/llvm-mingw'
+          repository: "mstorsjo/llvm-mingw"
           tag: 20240619
           fileName: llvm-mingw-20240619-ucrt-ubuntu-20.04-x86_64.tar.xz
           tarBall: false
@@ -123,18 +149,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '8'
+          distribution: "temurin"
+          java-version: "8"
       - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
       - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -163,18 +189,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '8'
+          distribution: "temurin"
+          java-version: "8"
       - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
       - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -192,6 +218,7 @@ jobs:
   pack-natives:
     environment: OSSRH
     needs:
+      - apple-natives
       - most-natives
       - windows-testing
       - linux-testing
@@ -199,18 +226,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: 'recursive'
+          submodules: "recursive"
       - name: Set up JDK 8
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '8'
+          distribution: "temurin"
+          java-version: "8"
       - run: echo "JAVA_8=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up JDK 11
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: "temurin"
+          java-version: "11"
       - run: echo "JAVA_11=$JAVA_HOME" >> $GITHUB_ENV
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+java = "corretto-8"
+ant = "latest"

--- a/lua51/build.gradle
+++ b/lua51/build.gradle
@@ -57,7 +57,15 @@ jnigen {
         cFlags += linuxFlags
         cppFlags += linuxFlags
     }
-    // Removed Android, iOS, MacOS, robovm, and other extra targets for minimal desktop build
+
+    add(MacOsX, x64)
+    add(MacOsX, x64, ARM)
+    each({ it.os == MacOsX }) {
+        String macFlags = ' -DLUA_USE_DLOPEN '
+        libraries = ''
+        cFlags += macFlags
+        cppFlags += macFlags
+    }
 }
 
 artifacts {

--- a/lua52/build.gradle
+++ b/lua52/build.gradle
@@ -59,7 +59,15 @@ jnigen {
         cFlags += linuxFlags
         cppFlags += linuxFlags
     }
-    // Removed Android, iOS, MacOS, robovm, and other extra targets for minimal desktop build
+
+    add(MacOsX, x64)
+    add(MacOsX, x64, ARM)
+    each({ it.os == MacOsX }) {
+        String macFlags = ' -DLUA_USE_DLOPEN '
+        libraries = ''
+        cFlags += macFlags
+        cppFlags += macFlags
+    }
 }
 
 artifacts {

--- a/lua53/build.gradle
+++ b/lua53/build.gradle
@@ -59,7 +59,15 @@ jnigen {
         cFlags += linuxFlags
         cppFlags += linuxFlags
     }
-    // Removed Android, iOS, MacOS, robovm, and other extra targets for minimal desktop build
+
+    add(MacOsX, x64)
+    add(MacOsX, x64, ARM)
+    each({ it.os == MacOsX }) {
+        String macFlags = ' -DLUA_USE_DLOPEN '
+        libraries = ''
+        cFlags += macFlags
+        cppFlags += macFlags
+    }
 }
 
 artifacts {

--- a/lua54/build.gradle
+++ b/lua54/build.gradle
@@ -59,7 +59,15 @@ jnigen {
         cFlags += linuxFlags
         cppFlags += linuxFlags
     }
-    // Removed Android, iOS, MacOS, robovm, and other extra targets for minimal desktop build
+
+    add(MacOsX, x64)
+    add(MacOsX, x64, ARM)
+    each({ it.os == MacOsX }) {
+        String macFlags = ' -DLUA_USE_DLOPEN '
+        libraries = ''
+        cFlags += macFlags
+        cppFlags += macFlags
+    }
 }
 
 artifacts {

--- a/luajit/build.gradle
+++ b/luajit/build.gradle
@@ -41,10 +41,13 @@ dependencies {
 }
 
 enum Platform {
-    // Only keep Linux and Windows platforms needed
+    // Desktop platforms: Linux, Windows, and macOS
     Linux64,
     AArch64,
     Win64,
+    MacOsX,
+    MacOsXAArch64,
+    MacOsXMerged, // Merged libluajit.a for macOS universal binary
 }
 
 // Builds LuaJIT and copies the output libluajit.a to jni/luajit/lib/${platform}
@@ -114,7 +117,13 @@ buildLuaTargets(
                 ['make', 'amalg',
                  'HOST_CC=gcc -m64', 'CFLAGS=-fPIC -DLUAJIT_ENABLE_LUA52COMPAT',
                  'BUILDMODE=static',
-                 'CROSS=x86_64-w64-mingw32-', 'TARGET_SYS=Windows'])
+                 'CROSS=x86_64-w64-mingw32-', 'TARGET_SYS=Windows']),
+        addLuaJitTarget(Platform.MacOsX,
+                ['make', 'amalg', 'TARGET_FLAGS=-arch x86_64',
+                 'CFLAGS=-fPIC', 'TARGET_SYS=Darwin']),
+        addLuaJitTarget(Platform.MacOsXAArch64,
+                ['make', 'amalg', 'TARGET_FLAGS=-arch arm64',
+                 'CFLAGS=-fPIC', 'TARGET_SYS=Darwin']),
 )
 
 void linkerConfig(BuildTarget it, Platform platform) {
@@ -147,14 +156,39 @@ jnigen {
     add(Windows, x64, x86, {
         linkerConfig(it, Platform.Win64)
     })
-    // Removed Android, iOS, MacOS, robovm, and other extra targets for minimal desktop build
+
+    add(MacOsX, x64, x86, {
+        linkerConfig(it, Platform.MacOsXMerged)
+    })
+    add(MacOsX, x64, ARM, {
+        linkerConfig(it, Platform.MacOsXMerged)
+    })
 }
 
 
-// Removed MacOS, Android, iOS, and other extra build dependencies for minimal desktop build
+tasks.register('buildLuaMacOsXMerge', {
+    dependsOn tasks.buildLuaMacOsX, tasks.buildLuaMacOsXAArch64
+    String pathX86 = "lib/${Platform.MacOsX.toString().toLowerCase()}"
+    String pathAArch64 = "lib/${Platform.MacOsXAArch64.toString().toLowerCase()}"
+    String pathA = "lib/${Platform.MacOsXMerged.toString().toLowerCase()}"
+    doLast {
+        exec {
+            workingDir 'jni/luajit'
+            commandLine 'mkdir', '-p', pathA
+        }
+        exec {
+            workingDir 'jni/luajit'
+            commandLine 'lipo', '-create',
+                    "${pathX86}/libluajit.a", "${pathAArch64}/libluajit.a",
+                    '-output', "${pathA}/libluajit.a"
+        }
+    }
+})
+
 tasks.jnigenBuildLinux64.dependsOn(tasks.buildLuaLinux64)
 tasks.jnigenBuildLinuxARM64.dependsOn(tasks.buildLuaAArch64)
 tasks.jnigenBuildWindows64.dependsOn(tasks.buildLuaWin64)
+tasks.jnigenBuildMacOsX64.dependsOn(tasks.buildLuaMacOsXMerge)
 
 void addPatchElfTask(String platform) {
     String target = "patchElf${platform}"


### PR DESCRIPTION
This PR restores macOS support for both Intel (x64) and Apple Silicon (ARM64) architectures that was removed in the minimal desktop build.

## Changes
- Added macOS x64 and ARM64 build targets to Lua 5.1, 5.2, 5.3, 5.4
- Added macOS x64 and ARM64 build targets to LuaJIT with universal binary support
- Added lipo merge task for creating macOS universal binaries
- Configured macOS-specific compiler flags (DLOPEN, library settings)
- Added mise configuration for consistent build tooling

## Testing
All native libraries build successfully on macOS:
- ✅ Lua 5.4 x64 and ARM64 dylibs generated
- ✅ LuaJIT universal binary created and verified with `lipo -info`
- ✅ Both architectures produce valid Mach-O libraries

## Keeps all LuaLink improvements:
- UTF-8 string handling fixes
- Fast-reflection performance improvements
- Better error messages
- LuaJIT 5.2 compatibility